### PR TITLE
fix: fix imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "@material-ui/icons": "^1.0.0",
     "react-transition-group": "^1.1.3",
     "react-scripts": "1.0.7",
-    "react-tap-event-plugin": "^2.0.1",
     "prop-types": "^15.5.10"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -20,16 +20,16 @@
     "babel-preset-react": "^6.24.1",
     "eslint": "^4.19.1",
     "eslint-plugin-react": "^7.10.0",
-    "eslint-plugin-prettier": "^2.6.2",
+    "eslint-plugin-prettier": "^2.6.2"
+  },
+  "dependencies": {
+    "react": "^16.4.1",
+    "react-dom": "^16.4.1",
     "@material-ui/core": "^1.0.0",
     "@material-ui/icons": "^1.0.0",
     "react-transition-group": "^1.1.3",
     "react-scripts": "1.0.7",
     "prop-types": "^15.5.10"
-  },
-  "peerDependencies": {
-    "react": "^16.4.1",
-    "react-dom": "^16.4.1"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
Fix #16 

When installed with `npm install`, `devDependencies` are not installed.
The dependencies are required to use this package, so set them in `dependencies`.